### PR TITLE
feat: Phase 2 - Data Models and Validation

### DIFF
--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const MemberFormSchema = z.object({
+  name: z.string().trim().optional(),
+  email: z
+    .string()
+    .email('有効なメールアドレスを入力してください')
+    .trim(),
+  age: z
+    .number()
+    .int()
+    .min(13, '年齢は13歳から120歳の間で入力してください')
+    .max(120, '年齢は13歳から120歳の間で入力してください'),
+  gender: z.enum(['男性', '女性', 'その他'], {
+    errorMap: () => ({ message: '性別を選択してください' }),
+  }),
+  hairType: z.enum(['直毛', 'くせ毛', 'その他'], {
+    errorMap: () => ({ message: '髪質を選択してください' }),
+  }),
+  agreeToPrivacy: z
+    .boolean()
+    .refine((val) => val === true, {
+      message: 'プライバシーポリシーに同意する必要があります',
+    }),
+});
+
+export type MemberFormInput = z.infer<typeof MemberFormSchema>;

--- a/types/member.ts
+++ b/types/member.ts
@@ -1,0 +1,36 @@
+import { Timestamp } from 'firebase/firestore';
+
+/**
+ * 会員データモデル
+ */
+export interface Member {
+  id: string;
+  name: string | null;
+  email: string;
+  age: number;
+  gender: '男性' | '女性' | 'その他';
+  hairType: '直毛' | 'くせ毛' | 'その他';
+  memberId: string;
+  issuedAt: Timestamp;
+}
+
+/**
+ * 会員登録フォームデータ
+ */
+export interface MemberFormData {
+  name?: string;
+  email: string;
+  age: number;
+  gender: '男性' | '女性' | 'その他';
+  hairType: '直毛' | 'くせ毛' | 'その他';
+  agreeToPrivacy: boolean;
+}
+
+/**
+ * 会員登録結果
+ */
+export interface RegisterMemberResult {
+  success: boolean;
+  memberId?: string;
+  error?: string;
+}


### PR DESCRIPTION
**Phase 2 Implementation:**
- ✅ TypeScript型定義 (タスク2)
- ✅ Zodバリデーションスキーマ (タスク2.1)

**Files created:**
- types/member.ts (Member, MemberFormData, RegisterMemberResult)
- lib/validation.ts (MemberFormSchema with Japanese error messages)

**Validation rules:**
- name: optional string (trimmed)
- email: RFC-compliant email with Japanese error message
- age: 13-120 range validation
- gender: enum ['男性', '女性', 'その他']
- hairType: enum ['直毛', 'くせ毛', 'その他']
- agreeToPrivacy: must be true

🤖 Generated with [Claude Code](https://claude.com/claude-code)