### PR TITLE
feat: Phase 5 - Top Page Implementation

### DIFF
--- a/app/actions/register-member.ts
+++ b/app/actions/register-member.ts
@@ -80,7 +80,7 @@ export async function registerMember(
     // エラーハンドリング
     if (error instanceof ZodError) {
       // Zodエラーの詳細を返す
-      const fieldErrors = error.errors.map((e) => ({
+      const fieldErrors = error.issues.map((e) => ({
         field: e.path.join('.'),
         message: e.message,
       }));

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,62 @@
+import { Suspense } from 'react';
+import Link from 'next/link';
+import MemberCount from '@/components/MemberCount';
+import ForecastMap from '@/components/ForecastMap';
+import NewsSection from '@/components/NewsSection';
+
+function MemberCountSkeleton() {
+  return (
+    <div className="card-official text-center animate-pulse">
+      <h2 className="text-2xl font-bold text-navy mb-4">現在の会員数</h2>
+      <div className="h-20 bg-gray-200 rounded mb-2"></div>
+      <div className="h-4 bg-gray-200 rounded w-48 mx-auto"></div>
+    </div>
+  );
+}
+
 export default function HomePage() {
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-4xl font-bold text-gold text-center mb-8">
-        クセは個性、個性は文化。
-      </h1>
-      <p className="text-white text-center">
-        日本天パ協会へようこそ（仮ページ）
-      </p>
+    <div className="container mx-auto px-4 py-12">
+      {/* Hero Section */}
+      <section className="text-center mb-16">
+        <h1 className="text-5xl md:text-6xl font-bold text-gold mb-6">
+          クセは個性、個性は文化。
+        </h1>
+        <p className="text-xl text-white mb-8">
+          日本天パ協会は、天然パーマの個性を文化として認め、
+          <br />
+          すべての天パの方々が誇りを持てる社会を目指します。
+        </p>
+        <Link href="/join" className="btn-primary text-lg px-8 py-4">
+          入会試験を受ける
+        </Link>
+      </section>
+
+      {/* Member Count & Forecast */}
+      <div className="grid md:grid-cols-2 gap-8 mb-12">
+        <Suspense fallback={<MemberCountSkeleton />}>
+          <MemberCount />
+        </Suspense>
+        <ForecastMap />
+      </div>
+
+      {/* News Section */}
+      <section className="mb-12">
+        <NewsSection />
+      </section>
+
+      {/* CTA Section */}
+      <section className="card-official text-center bg-gradient-to-r from-navy to-blue-900">
+        <h2 className="text-3xl font-bold text-gold mb-4">
+          日本天パ協会の一員になりませんか？
+        </h2>
+        <p className="text-white mb-6">
+          入会試験は誰でも合格できます。あなたの天パを認定しましょう。
+        </p>
+        <Link href="/join" className="btn-primary">
+          今すぐ入会試験を受ける
+        </Link>
+      </section>
     </div>
   );
 }

--- a/components/ForecastMap.tsx
+++ b/components/ForecastMap.tsx
@@ -1,0 +1,21 @@
+import Image from 'next/image';
+
+export default function ForecastMap() {
+  return (
+    <div className="card-official">
+      <h2 className="text-2xl font-bold text-navy mb-4">本日の天パ天気予報</h2>
+      <div className="relative w-full aspect-[16/9] bg-gray-100 rounded-lg overflow-hidden">
+        <Image
+          src="/forecast/latest.png"
+          alt="天パ天気予報マップ"
+          fill
+          className="object-contain"
+          priority
+        />
+      </div>
+      <p className="text-sm text-gray-600 mt-4 text-center">
+        毎朝7:30更新 | 6都市の天パ爆発指数
+      </p>
+    </div>
+  );
+}

--- a/components/MemberCount.tsx
+++ b/components/MemberCount.tsx
@@ -1,0 +1,13 @@
+import { getMemberCount } from '@/lib/actions/members';
+
+export default async function MemberCount() {
+  const count = await getMemberCount();
+
+  return (
+    <div className="card-official text-center">
+      <h2 className="text-2xl font-bold text-navy mb-4">現在の会員数</h2>
+      <div className="text-6xl font-bold text-gold mb-2">{count.toLocaleString()}</div>
+      <p className="text-gray-600">名の天パ会員が登録しています</p>
+    </div>
+  );
+}

--- a/components/NewsSection.tsx
+++ b/components/NewsSection.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+
+const news = [
+  {
+    id: 1,
+    date: '2025-01-15',
+    title: '新規会員登録システムを公開しました',
+    excerpt: '入会試験と会員証発行機能が利用可能になりました。',
+  },
+  {
+    id: 2,
+    date: '2025-01-10',
+    title: '天パ予報マップの自動生成を開始',
+    excerpt: '毎朝7:30に最新の天パ爆発指数マップを更新します。',
+  },
+  {
+    id: 3,
+    date: '2025-01-05',
+    title: '日本天パ協会公式サイトを開設',
+    excerpt: '天パの個性を文化として認める協会活動を開始しました。',
+  },
+];
+
+export default function NewsSection() {
+  return (
+    <div className="card-official">
+      <h2 className="text-2xl font-bold text-navy mb-6">お知らせ</h2>
+      <div className="space-y-4">
+        {news.map((item) => (
+          <Link
+            key={item.id}
+            href={`/news/${item.id}`}
+            className="block p-4 rounded-lg border border-gray-200 hover:border-gold hover:shadow-md transition-all"
+          >
+            <time className="text-sm text-gray-500">{item.date}</time>
+            <h3 className="text-lg font-bold text-navy mt-1">{item.title}</h3>
+            <p className="text-gray-600 mt-2">{item.excerpt}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/actions/members.ts
+++ b/lib/actions/members.ts
@@ -1,0 +1,16 @@
+'use server';
+
+import { adminDb } from '@/lib/firebase';
+
+export async function getMemberCount(): Promise<number> {
+  try {
+    if (!adminDb) {
+      return 0; // Firebase未設定時は0を返す
+    }
+    const membersSnapshot = await adminDb.collection('members').count().get();
+    return membersSnapshot.data().count;
+  } catch (error) {
+    console.error('Failed to get member count:', error);
+    return 0;
+  }
+}

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -2,14 +2,22 @@
 import { initializeApp, getApps, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
-if (!getApps().length) {
+// ビルド時やFirebase未設定時のモックデータ
+const isDevelopment = process.env.NODE_ENV !== 'production';
+const hasFirebaseConfig = Boolean(
+  process.env.FIREBASE_PROJECT_ID &&
+  process.env.FIREBASE_CLIENT_EMAIL &&
+  process.env.FIREBASE_PRIVATE_KEY
+);
+
+if (!getApps().length && hasFirebaseConfig) {
   initializeApp({
     credential: cert({
-      projectId: process.env.FIREBASE_PROJECT_ID,
-      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      projectId: process.env.FIREBASE_PROJECT_ID!,
+      clientEmail: process.env.FIREBASE_CLIENT_EMAIL!,
+      privateKey: process.env.FIREBASE_PRIVATE_KEY!.replace(/\\n/g, '\n'),
     }),
   });
 }
 
-export const adminDb = getFirestore();
+export const adminDb = hasFirebaseConfig ? getFirestore() : null as any;

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -12,10 +12,10 @@ export const MemberFormSchema = z.object({
     .min(13, '年齢は13歳から120歳の間で入力してください')
     .max(120, '年齢は13歳から120歳の間で入力してください'),
   gender: z.enum(['男性', '女性', 'その他'], {
-    errorMap: () => ({ message: '性別を選択してください' }),
+    message: '性別を選択してください',
   }),
   hairType: z.enum(['直毛', 'くせ毛', 'その他'], {
-    errorMap: () => ({ message: '髪質を選択してください' }),
+    message: '髪質を選択してください',
   }),
   agreeToPrivacy: z
     .boolean()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
- Implement hero section with association slogan
- Add MemberCount component with Firestore integration
- Add ForecastMap component for daily weather display
- Add NewsSection with recent announcements
- Create CTA buttons for join page navigation
- Fix ZodError handling (error.issues instead of error.errors)
- Fix zod enum validation (use message instead of errorMap)
- Add Firebase null check for build-time safety
- Add tsconfig.json with path aliases
- Create forecast image directory

Features:
✅ Hero section with slogan "クセは個性、個性は文化。"
✅ Real-time member count from Firestore
✅ Daily curly hair forecast map display
✅ Recent news section (3 items)
✅ Join exam CTA buttons
✅ Responsive design with TailwindCSS
✅ Server-side data fetching with Suspense

🤖 Generated with [Claude Code](https://claude.com/claude-code)