### PR TITLE
feat: Phase 6 - About Page Implementation

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,155 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '協会について | 日本天パ協会',
+  description: '日本天パ協会のミッション、組織体制、倫理規定について',
+};
+
+const leadership = [
+  {
+    title: '会長',
+    name: '天野 巻雄',
+    description: '元気象予報士。湿度60%超えで爆発する天パを持つ。',
+  },
+  {
+    title: '副会長',
+    name: '雨宮 渦子',
+    description: '美容業界出身。縮毛矯正を5回挫折した経験を持つ。',
+  },
+  {
+    title: '事務局長',
+    name: '梅田 螺旋',
+    description: '元弁護士。天パ差別訴訟で勝訴経験あり。',
+  },
+];
+
+const ethics = [
+  {
+    title: '寝癖差別禁止',
+    description:
+      '寝起きの天パを「寝癖」と呼ぶことを禁止します。それは自然な形状です。',
+  },
+  {
+    title: '梅雨期の直毛優遇を認めない',
+    description:
+      '梅雨時期に「髪が広がらなくていいね」と直毛の方を優遇する発言を禁止します。',
+  },
+  {
+    title: 'ストレート至上主義の否定',
+    description:
+      'サラサラストレートが美の基準とする価値観を否定し、多様性を尊重します。',
+  },
+  {
+    title: '無断での髪質判定禁止',
+    description:
+      '「これ天パ？」「パーマかけてるの？」など、許可なく髪質を詮索することを禁止します。',
+  },
+  {
+    title: '縮毛矯正の強要禁止',
+    description:
+      '「ストレートにすれば？」など、髪質の変更を強要する発言を禁止します。',
+  },
+];
+
+export default function AboutPage() {
+  return (
+    <div className="container mx-auto px-4 py-12">
+      {/* Mission Section */}
+      <section className="card-official mb-12">
+        <h1 className="text-4xl font-bold text-navy mb-8 text-center">
+          協会について
+        </h1>
+
+        <div className="space-y-6 text-gray-700">
+          <div>
+            <h2 className="text-2xl font-bold text-navy mb-4">ミッション</h2>
+            <p className="leading-relaxed">
+              日本天パ協会は、天然パーマという個性を単なる髪質の違いではなく、
+              文化的アイデンティティとして認識し、すべての天パの方々が自信と誇りを持てる社会の実現を目指します。
+            </p>
+            <p className="leading-relaxed mt-4">
+              私たちは、長年にわたり「扱いにくい」「だらしない」といった
+              不当な評価を受けてきた天パの歴史を変革し、
+              その独自性と魅力を広く社会に発信します。
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-bold text-navy mb-4">ビジョン</h2>
+            <ul className="list-disc list-inside space-y-2">
+              <li>天パへの偏見と差別のない社会の実現</li>
+              <li>天パ特有の悩みを共有し、解決策を提供するコミュニティの構築</li>
+              <li>天パの美しさと多様性を称える文化の醸成</li>
+              <li>気象条件と天パの関係性に関する科学的研究の推進</li>
+            </ul>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-bold text-navy mb-4">活動内容</h2>
+            <ul className="list-disc list-inside space-y-2">
+              <li>天パ天気予報の毎日更新（湿度・露点・爆発指数）</li>
+              <li>天パに関する正しい知識の啓発活動</li>
+              <li>会員向け情報誌「うねり通信」の発行（月刊）</li>
+              <li>全国天パサミットの開催（年1回）</li>
+              <li>天パフレンドリー美容室認定制度の運営</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      {/* Leadership Section */}
+      <section className="card-official mb-12">
+        <h2 className="text-3xl font-bold text-navy mb-8 text-center">
+          組織体制
+        </h2>
+        <div className="grid md:grid-cols-3 gap-6">
+          {leadership.map((member) => (
+            <div
+              key={member.title}
+              className="p-6 border border-gray-200 rounded-lg hover:border-gold transition-colors"
+            >
+              <div className="text-center mb-4">
+                <div className="w-24 h-24 mx-auto bg-gradient-to-br from-navy to-blue-900 rounded-full flex items-center justify-center mb-4">
+                  <span className="text-3xl text-gold">👤</span>
+                </div>
+                <h3 className="text-lg font-bold text-gold mb-1">
+                  {member.title}
+                </h3>
+                <p className="text-xl font-bold text-navy">{member.name}</p>
+              </div>
+              <p className="text-sm text-gray-600 text-center">
+                {member.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Ethics Section */}
+      <section className="card-official">
+        <h2 className="text-3xl font-bold text-navy mb-8 text-center">
+          倫理規定
+        </h2>
+        <div className="space-y-6">
+          {ethics.map((rule, index) => (
+            <div
+              key={index}
+              className="p-6 border-l-4 border-gold bg-gray-50 rounded-r-lg"
+            >
+              <h3 className="text-xl font-bold text-navy mb-2">
+                第{index + 1}条　{rule.title}
+              </h3>
+              <p className="text-gray-700">{rule.description}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+          <p className="text-sm text-gray-600 text-center">
+            ※ 本倫理規定は、すべての会員および天パを持つ方々の尊厳を守るために制定されました。
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
- Implement about page with mission statement
- Add leadership section (会長, 副会長, 事務局長)
- Add ethics section with 5 rules
- Include vision and activities sections

Features:
✅ Mission: 天パの文化的アイデンティティの確立
✅ Vision: 4つのビジョン項目
✅ Activities: 5つの活動内容（天パ予報、啓発、会報、サミット、認定制度）
✅ Leadership: 3名の役員紹介（小ネタ入り経歴）
✅ Ethics: 5つの倫理規定
  - 寝癖差別禁止
  - 梅雨期の直毛優遇を認めない
  - ストレート至上主義の否定
  - 無断での髪質判定禁止
  - 縮毛矯正の強要禁止

Design:
- 官公庁風レイアウト（card-official）
- 3カラムグリッド（役員紹介）
- 左ボーダー付きカード（倫理規定）
- アイコン使用（👤 for leadership）
- レスポンシブ対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)