### PR TITLE
feat: Phase 7 - Join Exam Page Implementation

### DIFF
--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { examQuestions, isAllAnswered } from '@/lib/exam-questions';
+
+export default function JoinExamPage() {
+  const router = useRouter();
+  const [answers, setAnswers] = useState<Record<number, number>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleAnswerChange = (questionId: number, optionIndex: number) => {
+    setAnswers((prev) => ({
+      ...prev,
+      [questionId]: optionIndex,
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!isAllAnswered(answers)) {
+      alert('すべての質問に回答してください');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    // 送信処理（わずかな遅延で体験向上）
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // 結果ページへ遷移（必ず合格）
+    router.push('/join/result');
+  };
+
+  const allAnswered = isAllAnswered(answers);
+  const answeredCount = Object.keys(answers).length;
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-4xl">
+      <div className="card-official mb-8">
+        <h1 className="text-4xl font-bold text-navy mb-4 text-center">
+          入会試験
+        </h1>
+        <p className="text-gray-600 text-center mb-6">
+          全10問の質問に答えてください。すべて選択すると送信できます。
+        </p>
+        <div className="flex items-center justify-center gap-2 text-sm">
+          <span className="text-gray-600">回答済み:</span>
+          <span className="font-bold text-navy">
+            {answeredCount} / {examQuestions.length}
+          </span>
+          {allAnswered && (
+            <span className="ml-2 text-gold">✓ すべて回答完了</span>
+          )}
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-8">
+        {examQuestions.map((question) => (
+          <div key={question.id} className="card-official">
+            <div className="mb-4">
+              <span className="inline-block bg-navy text-gold px-3 py-1 rounded text-sm font-bold mb-2">
+                問{question.id}
+              </span>
+              <h2 className="text-xl font-bold text-navy">
+                {question.question}
+              </h2>
+            </div>
+
+            <div className="space-y-3">
+              {question.options.map((option, index) => (
+                <label
+                  key={index}
+                  className={`block p-4 border-2 rounded-lg cursor-pointer transition-all ${
+                    answers[question.id] === index
+                      ? 'border-gold bg-gold bg-opacity-10'
+                      : 'border-gray-200 hover:border-gray-300'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name={`question-${question.id}`}
+                    value={index}
+                    checked={answers[question.id] === index}
+                    onChange={() => handleAnswerChange(question.id, index)}
+                    className="mr-3 accent-gold"
+                  />
+                  <span className="text-gray-700">{option}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        <div className="text-center pt-4">
+          <button
+            type="submit"
+            disabled={!allAnswered || isSubmitting}
+            className="btn-primary text-lg px-12 py-4 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? '送信中...' : '試験を送信する'}
+          </button>
+          {!allAnswered && (
+            <p className="text-sm text-gray-500 mt-3">
+              すべての質問に回答すると送信できます
+            </p>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/lib/exam-questions.ts
+++ b/lib/exam-questions.ts
@@ -1,0 +1,136 @@
+export interface Question {
+  id: number;
+  question: string;
+  options: string[];
+  correctAnswer: number;
+}
+
+export const examQuestions: Question[] = [
+  // 前半5問: 真面目な質問
+  {
+    id: 1,
+    question: '天然パーマの主な原因として正しいものはどれですか？',
+    options: [
+      '毛根の形状が曲がっているため',
+      '栄養不足によるもの',
+      'シャンプーの選び方が間違っているため',
+    ],
+    correctAnswer: 0,
+  },
+  {
+    id: 2,
+    question: '湿度が高い日に天パが広がりやすい理由は？',
+    options: [
+      '髪が水分を吸収して膨張するため',
+      '静電気が発生しやすいため',
+      '気圧の変化により髪質が変わるため',
+    ],
+    correctAnswer: 0,
+  },
+  {
+    id: 3,
+    question: '天パの方に適したヘアケア方法はどれですか？',
+    options: [
+      '毎日ブラッシングを念入りに行う',
+      '保湿重視のトリートメントを使用する',
+      'ドライヤーは使わず自然乾燥させる',
+    ],
+    correctAnswer: 1,
+  },
+  {
+    id: 4,
+    question: '縮毛矯正の効果が持続する期間の目安は？',
+    options: [
+      '約1ヶ月',
+      '約3〜6ヶ月',
+      '約1年以上',
+    ],
+    correctAnswer: 1,
+  },
+  {
+    id: 5,
+    question: '天パの遺伝について正しいものはどれですか？',
+    options: [
+      '優性遺伝のため、両親のどちらかが天パなら子供も天パになりやすい',
+      '劣性遺伝のため、両親が直毛でも天パが生まれることがある',
+      '遺伝とは無関係で、環境要因で決まる',
+    ],
+    correctAnswer: 0,
+  },
+  // 後半5問: ネタ質問
+  {
+    id: 6,
+    question: '梅雨時期の天パあるあるとして最も共感できるものは？',
+    options: [
+      '朝のセットが完全に無意味になる',
+      '髪が勝手に雨を予報してくれる',
+      '湿度計として友人に重宝される',
+    ],
+    correctAnswer: 1,
+  },
+  {
+    id: 7,
+    question: '寝起きの天パを見た家族の反応として最も多いのは？',
+    options: [
+      '「爆発してるよ」',
+      '「芸術作品みたい」',
+      '「今日は特に元気だね（髪が）」',
+    ],
+    correctAnswer: 0,
+  },
+  {
+    id: 8,
+    question: '直毛の人に言われて最もイラッとする言葉は？',
+    options: [
+      '「パーマかけてるの？」',
+      '「天パいいじゃん、お金かからなくて」',
+      '「ストレートにすればいいのに」',
+    ],
+    correctAnswer: 2,
+  },
+  {
+    id: 9,
+    question: '天パ協会の公式マスコットの名前は何でしょう？',
+    options: [
+      'うねうね君',
+      'くるりん',
+      'もじゃ丸',
+    ],
+    correctAnswer: 1,
+  },
+  {
+    id: 10,
+    question: '天パの最大の敵は次のうちどれですか？',
+    options: [
+      '梅雨',
+      '台風',
+      '人類の「サラサラストレート至上主義」',
+    ],
+    correctAnswer: 2,
+  },
+];
+
+// すべての質問に答えたかチェック
+export function isAllAnswered(answers: Record<number, number>): boolean {
+  return examQuestions.every((q) => answers[q.id] !== undefined);
+}
+
+// 合否判定（必ず合格）
+export function getExamResult(answers: Record<number, number>): {
+  passed: boolean;
+  score: number;
+  totalQuestions: number;
+} {
+  let correctCount = 0;
+  examQuestions.forEach((q) => {
+    if (answers[q.id] === q.correctAnswer) {
+      correctCount++;
+    }
+  });
+
+  return {
+    passed: true, // 必ず合格
+    score: correctCount,
+    totalQuestions: examQuestions.length,
+  };
+}


### PR DESCRIPTION
- Create exam questions data (10 questions)
- Implement exam form with answer state management
- Add answer validation and progress tracking
- Add submit handling with result page navigation

Features:
✅ 10 Questions (前半5問: 真面目, 後半5問: ネタ)
✅ Answer state management with useState
✅ Progress counter (answered X / 10)
✅ Submit button disabled until all answered
✅ Visual feedback for selected answers
✅ Auto-navigation to result page after submit
✅ Always passes (必ず合格)

Question Topics:
- Q1-5: 真面目な天パ知識
  - 毛根の形状、湿度の影響、ヘアケア、縮毛矯正、遺伝
- Q6-10: ネタ質問
  - 梅雨あるあるalert、寝癖、直毛の人の発言、マスコット、最大の敵

UI/UX:
- Card-based layout for each question
- Radio buttons with hover effects
- Selected answer highlighted with gold border
- Progress indicator at top
- Disabled submit button with visual feedback
- Loading state during submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)