### PR TITLE
fix: NewsSection 404エラー解消とFirebase接続エラーハンドリング追加

### DIFF
--- a/app/actions/register-member.ts
+++ b/app/actions/register-member.ts
@@ -38,6 +38,15 @@ export async function registerMember(
   formData: MemberFormData
 ): Promise<RegisterMemberResult> {
   try {
+    // 0. Firebase接続チェック
+    if (!adminDb) {
+      console.error('Firebase Admin SDK is not initialized');
+      return {
+        success: false,
+        error: 'データベース接続エラー。環境変数を確認してください。',
+      };
+    }
+
     // 1. Zodバリデーション
     const validated = MemberFormSchema.parse(formData);
 

--- a/components/NewsSection.tsx
+++ b/components/NewsSection.tsx
@@ -24,18 +24,17 @@ const news = [
 export default function NewsSection() {
   return (
     <div className="card-official">
-      <h2 className="text-2xl font-bold text-navy mb-6">お知らせ</h2>
+      <h2 className="text-2xl font-semibold text-navy mb-6">お知らせ</h2>
       <div className="space-y-4">
         {news.map((item) => (
-          <Link
+          <div
             key={item.id}
-            href={`/news/${item.id}`}
-            className="block p-4 rounded-lg border border-gray-200 hover:border-gold hover:shadow-md transition-all"
+            className="block p-4 rounded-lg border border-gray-200"
           >
             <time className="text-sm text-gray-500">{item.date}</time>
-            <h3 className="text-lg font-bold text-navy mt-1">{item.title}</h3>
+            <h3 className="text-lg font-semibold text-navy mt-1">{item.title}</h3>
             <p className="text-gray-600 mt-2">{item.excerpt}</p>
-          </Link>
+          </div>
         ))}
       </div>
     </div>


### PR DESCRIPTION
- NewsSection: /news/{id}へのリンクを無効化（ページ未実装）
- register-member: Firebase接続失敗時のエラーメッセージ追加

Fixes: /news/1, /news/2, /news/3の404エラー